### PR TITLE
Fixed issue in SetShareLimit  request (It requires minutes instead of seconds)

### DIFF
--- a/src/QBittorrent.Client/Converters/MinutesToTimeSpanConverter.cs.cs
+++ b/src/QBittorrent.Client/Converters/MinutesToTimeSpanConverter.cs.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Numerics;
+using Newtonsoft.Json;
+
+namespace QBittorrent.Client.Converters
+{
+    internal class MinutesToTimeSpanConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteValue(-1);
+                return;
+            }
+
+            writer.WriteValue((long)((TimeSpan)value).TotalMinutes);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            if (reader.TokenType == JsonToken.Integer)
+            {
+                if (reader.Value is BigInteger)
+                    return TimeSpan.MaxValue;
+
+                long totalMinutes = Convert.ToInt64(reader.Value);
+                if (totalMinutes >= 0)
+                {
+                    return totalMinutes > TimeSpan.MaxValue.Ticks / TimeSpan.TicksPerMinute
+                        ? TimeSpan.MaxValue
+                        : new TimeSpan(totalMinutes * TimeSpan.TicksPerMinute);
+                }
+                else
+                {
+                    return totalMinutes < TimeSpan.MinValue.Ticks / TimeSpan.TicksPerMinute
+                        ? TimeSpan.MinValue
+                        : new TimeSpan(totalMinutes * TimeSpan.TicksPerMinute);
+                }
+            }
+
+            throw new JsonSerializationException($"Unexpected token {reader.TokenType} when parsing integer.");
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(TimeSpan?);
+        }
+    }
+}

--- a/src/QBittorrent.Client/Internal/Api2RequestProvider.cs
+++ b/src/QBittorrent.Client/Internal/Api2RequestProvider.cs
@@ -96,7 +96,7 @@ namespace QBittorrent.Client.Internal
             return BuildForm(Url.SetShareLimits(),
                 ("hashes", JoinHashes(hashes)),
                 ("ratioLimit", ratio.ToString("R", CultureInfo.InvariantCulture)),
-                ("seedingTimeLimit", seedingTime.TotalSeconds.ToString("F0")));
+                ("seedingTimeLimit", seedingTime.TotalMinutes.ToString("F0")));
         }
 
         public override (Uri url, HttpContent request) BanPeers(IEnumerable<string> peers)

--- a/src/QBittorrent.Client/ShareLimits.cs
+++ b/src/QBittorrent.Client/ShareLimits.cs
@@ -33,12 +33,12 @@ namespace QBittorrent.Client
             /// <summary>
             /// Set global limit.
             /// </summary>
-            public static readonly TimeSpan Global = TimeSpan.FromSeconds(-2);
+            public static readonly TimeSpan Global = TimeSpan.FromMinutes(-2);
 
             /// <summary>
             /// Set no limit.
             /// </summary>
-            public static readonly TimeSpan Unlimited = TimeSpan.FromSeconds(-1);
+            public static readonly TimeSpan Unlimited = TimeSpan.FromMinutes(-1);
         }
     }
 }

--- a/src/QBittorrent.Client/TorrentPartialInfo.cs
+++ b/src/QBittorrent.Client/TorrentPartialInfo.cs
@@ -231,7 +231,7 @@ namespace QBittorrent.Client
         /// Upload seeding time limit 
         /// </summary>
         [JsonProperty("seeding_time_limit")]
-        [JsonConverter(typeof(SecondsToTimeSpanConverter))]
+        [JsonConverter(typeof(MinutesToTimeSpanConverter))]
         public TimeSpan? SeedingTimeLimit { get; set; }
 
         /// <summary>


### PR DESCRIPTION
The value of SeedingTimeLimit  for the request SetShareLimit  requires minutes instead of seconds. 
(This is only with the seeding time limit of this request the one from the add request uses seconds oh and btw keep up the good work!) 