### PR TITLE
Preserve path part of baseUri when building new URIs

### DIFF
--- a/src/QBittorrent.Client/Internal/BaseUrlProvider.cs
+++ b/src/QBittorrent.Client/Internal/BaseUrlProvider.cs
@@ -12,14 +12,16 @@ namespace QBittorrent.Client.Internal
             _baseUri = baseUri;
         }
 
-        private protected Uri Create(string relativeUri) => new Uri(_baseUri, relativeUri);
+        private protected Uri Create(string relativeUri) => new Uri(
+            _baseUri,
+            _baseUri.AbsolutePath.TrimEnd('/') + relativeUri);
 
         private protected Uri Create(string relativeUri, 
             params (string key, string value)[] parameters)
         {
             var builder = new UriBuilder(_baseUri)
             {
-                Path = relativeUri,
+                Path = _baseUri.AbsolutePath.TrimEnd('/') + relativeUri,
                 Query = string.Join("&", parameters
                     .Where(t => t.value != null)
                     .Select(t => $"{Uri.EscapeDataString(t.key)}={Uri.EscapeDataString(t.value)}"))

--- a/src/QBittorrent.Client/QBittorrentClient.cs
+++ b/src/QBittorrent.Client/QBittorrentClient.cs
@@ -1135,7 +1135,7 @@ namespace QBittorrent.Client
         {
             var builder = new UriBuilder(_uri)
             {
-                Path = path,
+                Path = _uri.AbsolutePath.TrimEnd('/') + path,
                 Query = string.Join("&", parameters
                     .Where(t => t.value != null)
                     .Select(t => $"{Uri.EscapeDataString(t.key)}={Uri.EscapeDataString(t.value)}"))


### PR DESCRIPTION
currently, the path part of the provided server URI (or base URI) is overwritten when new URIs are built, which leads to unexpected behavior, e.g.

- provided server URI: `https://blah.example/qbt/` or `https://blah.example/qbt`
- expected URI for v2 api login endpoint: `https://blah.example/qbt/api/v2/auth/login`
- actual URI: `https://blah.example/api/v2/auth/login`

this PR makes it such that the path part of the server URI is preserved when building new URIs (or at least it did when I tested this change)

should fix fedarovich/qbittorrent-cli#30 fedarovich/qbittorrent-cli#49