### PR TITLE
Update PeerPartialData class to handle potential null values

### DIFF
--- a/src/QBittorrent.Client/PeerPartialData.cs
+++ b/src/QBittorrent.Client/PeerPartialData.cs
@@ -26,7 +26,7 @@ namespace QBittorrent.Client
         ///   <see langword="false" /> if this object contains only changes of data since the previous request.
         /// </value>
         [JsonProperty("full_update")]
-        public bool FullUpdate { get; set; }
+        public bool FullUpdate? { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether flags must be shown.
@@ -35,24 +35,24 @@ namespace QBittorrent.Client
         ///   <see langword="true" /> if flags must be shown; otherwise, <see langword="false" />.
         /// </value>
         [JsonProperty("show_flags")]
-        public bool ShowFlags { get; set; }
+        public bool ShowFlags? { get; set; }
 
         /// <summary>
         /// Gets or sets the changed and new peers.
         /// </summary>
         [JsonProperty("peers")]
-        public IReadOnlyDictionary<string, PeerPartialInfo> PeersChanged { get; set; }
+        public IReadOnlyDictionary<string, PeerPartialInfo>? PeersChanged { get; set; }
 
         /// <summary>
         /// Gets or sets the removed peers.
         /// </summary>
         [JsonProperty("peers_removed")]
-        public IReadOnlyList<string> PeersRemoved { get; set; }
+        public IReadOnlyList<string>? PeersRemoved { get; set; }
 
         /// <summary>
         /// Additional properties not handled by this library.
         /// </summary>
         [JsonExtensionData]
-        public IDictionary<string, JToken> AdditionalData { get; set; }
+        public IDictionary<string, JToken>? AdditionalData { get; set; }
     }
 }


### PR DESCRIPTION
I was getting some null exceptions in my code whilst using `QBittorrent.GetPeerPartialDataSync` upon further investigation I noticed that the properties of PeerPartialData.cs aren't declared as nullable. 
I believe they should be nullable as a server reply might as small as just the rid, for example: `{"rid":55}`. 

This pull request makes all properties in the PeerPartialData class (except for ResponseId) nullable. This should make it clear to anyone utilising it that null values have to be handled where applicable.

This is just a quick edit/submission through the GitHub WebUI but only one file is affected, making things optionally nullable shouldn't lead to anything breaking.